### PR TITLE
Fixed javadoc errors

### DIFF
--- a/src/me/vrekt/lunar/Game.java
+++ b/src/me/vrekt/lunar/Game.java
@@ -238,6 +238,7 @@ public class Game implements Runnable {
     }
 
     /**
+     * Gets the width of the Game's window.
      * @return the width
      */
     public int getWidth() {
@@ -245,6 +246,7 @@ public class Game implements Runnable {
     }
 
     /**
+     * Gets the height of the Game's window.
      * @return the height
      */
     public int getHeight() {
@@ -268,7 +270,9 @@ public class Game implements Runnable {
     }
     
     /**
-     * @return the FPS
+     * Gets the FPS of the Game.
+     * @return the frames per second count,
+     * which is how many times the game renders in a given second.
      */
     public int getFPS() {
         return fps;

--- a/src/me/vrekt/lunar/Lunar.java
+++ b/src/me/vrekt/lunar/Lunar.java
@@ -11,6 +11,11 @@ public class Lunar {
 
     /**
      * Initialize the game.
+     * @param title The title of the game's window.
+     * @param width The width of the game's window.
+     * @param height The height of the game's window.
+     * @param tickRate indicates how fast the game is drawn/updated.
+     * A good tickrate is 64 or above.
      */
     public void initializeGame(String title, int width, int height, int tickRate) {
         game = new Game(title, width, height, tickRate);
@@ -21,6 +26,12 @@ public class Lunar {
 
     /**
      * Initialize the game.
+     * @param title The title of the game's window.
+     * @param width The width of the game's window.
+     * @param height The height of the game's window.
+     * @param state A default {@link GameState} object to use.
+     * @param tickRate indicates how fast the game is drawn/updated.
+     * A good tickrate is 64 or above.
      */
     public void initializeGame(String title, int width, int height, GameState state, int tickRate) {
         game = new Game(title, width, height, state, tickRate);

--- a/src/me/vrekt/lunar/collision/BoundingBox.java
+++ b/src/me/vrekt/lunar/collision/BoundingBox.java
@@ -4,11 +4,37 @@ import java.awt.Rectangle;
 
 public class BoundingBox {
 
-	public int x, y, width, height;
+	/**
+	 * The x origin of this BoundingBox.
+	 */
+	public int x;
+
+	/**
+	 * The y origin of this BoundingBox.
+	 */
+	public int y;
+
+	/**
+	 * The width of this BoundingBox.
+	 */
+	public int width;
+
+	/**
+	 * The height of this BoundingBox.
+	 */
+	public int height;
+
+	/**
+	 * The bounds of this BoundingBox.
+	 */
 	public Rectangle bounds;
 
 	/**
-	 * Initialize the boundingBox
+	 * Initialize the BoundingBox.
+	 * @param x The x origin to initialize this BoundingBox with.
+	 * @param y The y origin to initialize this BoundingBox with.
+	 * @param width The width to initialize this BoundingBox with.
+	 * @param height The height to initialize this BoundingBox with.
 	 */
 	public BoundingBox(int x, int y, int width, int height) {
 		this.x = x;
@@ -20,7 +46,11 @@ public class BoundingBox {
 	}
 
 	/**
-	 * Update the boundingBox.
+	 * Set the values of this BoundingBox.
+	 * @param x The x origin to set.
+	 * @param y The y origin to set.
+	 * @param width The width to set.
+	 * @param height The height to set.
 	 */
 	public void update(int x, int y, int width, int height) {
 		this.x = x;
@@ -32,7 +62,10 @@ public class BoundingBox {
 	}
 
 	/**
-	 * Return if the current boundingBox intersects with another.
+	 * Return if the current BoundingBox intersects with another.
+	 * @param box The other BoundingBox to check against.
+	 * @return True if the passed in BoundingBox intersects with this one,
+	 * otherwise false.
 	 */
 	public boolean doesIntersect(BoundingBox box) {
 		return bounds.intersects(box.bounds);

--- a/src/me/vrekt/lunar/entity/Entity.java
+++ b/src/me/vrekt/lunar/entity/Entity.java
@@ -23,7 +23,12 @@ public abstract class Entity {
     protected BufferedImage texture;
 
     /**
-     * Initialize the entity.
+     * Initialize the entity; this is the primary constructor.
+     * @param x The x position of this entity.
+     * @param y The y position of this entity.
+     * @param width The width of this entity.
+     * @param height The height of this entity.
+     * @param entityID A number uniquely identifiying this enemy.
      */
     public Entity(int x, int y, int width, int height, int entityID) {
         this.x = x;
@@ -39,7 +44,14 @@ public abstract class Entity {
     }
 
     /**
-     * Initialize the entity.
+     * Convenience constructor that allows you to
+     * specify a BoundingBox to use with this entity.
+     * @param x The x position of this entity.
+     * @param y The y position of this entity.
+     * @param width The width of this entity.
+     * @param height The height of this entity.
+     * @param entityID A number uniquely identifiying this enemy.
+     * @param bb The collision box for this entity.
      */
     public Entity(int x, int y, int width, int height, int entityID, BoundingBox bb) {
         this(x, y, width, height, entityID);
@@ -48,7 +60,14 @@ public abstract class Entity {
     }
 
     /**
-     * Initialize the entity.
+     * Convenience constructor that allows you to provide a
+     * BufferedImage to use as a texture for this entity.
+     * @param texture The image to use as a texture for this entity.
+     * @param x The x position of this entity.
+     * @param y The y position of this entity.
+     * @param width The width of this entity.
+     * @param height The height of this entity.
+     * @param entityID A number uniquely identifiying this enemy.
      */
     public Entity(BufferedImage texture, int x, int y, int width, int height, int entityID) {
         this(x, y, width, height, entityID);
@@ -58,7 +77,15 @@ public abstract class Entity {
     }
 
     /**
-     * Initialize the entity.
+     * Convenience constructor that allows you to supply both a BufferedImage
+     * and a BoundingBox.
+     * @param texture The image to use as a texture for this entity.
+     * @param x The x position of this entity.
+     * @param y The y position of this entity.
+     * @param width The width of this entity.
+     * @param height The height of this entity.
+     * @param entityID A number uniquely identifiying this enemy.
+     * @param bb The collision box for this entity.
      */
     public Entity(BufferedImage texture, int x, int y, int width, int height, int entityID, BoundingBox bb) {
         this(x, y, width, height, entityID, bb);
@@ -67,6 +94,12 @@ public abstract class Entity {
 
     }
 
+    /**
+     * Draw the entity's visual representation herea
+     * @param graphics A Graphics object for this method to draw to. It
+     * is the responsibility of the caller to make sure the Graphics object
+     * passed in is displayed on the screen.
+     */
     public abstract void drawEntity(Graphics graphics);
 
     public abstract void updateEntity();

--- a/src/me/vrekt/lunar/utilities/Utilities.java
+++ b/src/me/vrekt/lunar/utilities/Utilities.java
@@ -35,7 +35,7 @@ public class Utilities {
 
     /**
      * Linearly interpolate between (xi, yi) and (xf, yf) at time t. t should be incremented, and
-     * should satisfy 0 <= t <= 1.
+     * should satisfy {@literal 0 <= t <= 1.}
      */
     public static Location lerp(int xi, int yi, int xf, int yf, double t) {
         t = t % 1.0;
@@ -44,7 +44,7 @@ public class Utilities {
 
     /**
      * Linearly interpolate between (xi, yi) and (xf, yf) at time t. t should be incremented, and
-     * should satisfy 0 <= t <= 1.
+     * should satisfy {@literal 0 <= t <= 1.}
      */
     public static Location lerp(Location a, Location b, double t) {
         t = t % 1.0;
@@ -53,7 +53,7 @@ public class Utilities {
 
     /**
      * Linearly interpolate between a and b at time t. t should be incremented, and
-     * should be satisfy 0 <= t <= 1.
+     * should be satisfy {@literal 0 <= t <= 1.}
      */
     public static double lerp(double a, double b, double t) {
         t = t % 1.0;


### PR DESCRIPTION
Javadoc interpreted the < character as the start of an HTML tag and errors out. Wrapping it in a @literal tag fixes this.