### PR TITLE
Fix World Test

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,11 @@ Feel free to join and ask about anything related to Lunar.
 # Contributing
 
 When contributing and submitting requests for your changes to be merged please make sure to test your code and leave a note if the wiki needs to be updated!
+
+# Testing
+
+Use the bundled gradle distro to run tests. This should only be necessary when contributing.
+
+```bash
+./gradlew test
+```

--- a/src/main/java/com/lunar/location/Location.java
+++ b/src/main/java/com/lunar/location/Location.java
@@ -241,4 +241,49 @@ public class Location {
     public static Location lerp(Location from, Location to, double t) {
         return MathHelper.lerp(from, to, t);
     }
+
+    /**
+     * Two Locations are considered equal if their x's and y's are the same.
+     *
+     * The world instance is not checked as Locations are often instantiated without
+     * a world object available in the context.
+     *
+     * @param obj the other object
+     * @return true/false whether the objects are referentially or logically equal
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj instanceof Location) {
+            Location other = (Location)obj;
+
+            return this.x == other.x && this.y == other.y;
+        }
+
+        return super.equals(obj);
+    }
+
+    /**
+     * The hash code is calculated by combining the fields checked by the equals function
+     * into an int.
+     *
+     * Implementation taken from this thread on StackOverflow:
+     *  - https://stackoverflow.com/a/113600
+     *
+     * @return the object's hash code
+     */
+    @Override
+    public int hashCode() {
+        int result = 11;
+        result = 31 * this.x + result;
+        result = 31 * this.y + result;
+        return result;
+    }
 }

--- a/src/main/java/com/lunar/world/World.java
+++ b/src/main/java/com/lunar/world/World.java
@@ -98,8 +98,18 @@ public abstract class World extends MapRenderer {
     }
 
     public final void finishQueueActions() {
-        ENTITY_ACTION_LIST.forEach(entity -> removeEntity(entity.getThisEntity()));
-        ENTITY_ACTION_LIST.forEach(entity -> addEntity(entity.getThisEntity()));
+        // This logic could be moved to implementations of MutableEntity and use a
+        // factory to create them.
+        for (MutableEntity mut : ENTITY_ACTION_LIST) {
+            switch (mut.getAction()) {
+                case REMOVE:
+                    WORLD_ENTITIES.remove(mut.getThisEntity());
+                    break;
+                case ADD:
+                    WORLD_ENTITIES.add(mut.getThisEntity());
+                    break;
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/lunar/world/WorldMap.java
+++ b/src/main/java/com/lunar/world/WorldMap.java
@@ -65,13 +65,10 @@ public abstract class WorldMap {
      * @param amount    the amount of times to add the tile.
      */
     private void setMultiple(Tile tile, int startX, int startY, Direction direction, int amount) {
-        int iterations = 0;
-
         int width = tile.getWidth();
         int height = tile.getHeight();
 
-        while (iterations < amount) {
-            iterations++;
+        for (int i = 0; i < amount; i++) {
             tile.setY(startY);
             tile.setX(startX);
             set(tile);
@@ -126,13 +123,10 @@ public abstract class WorldMap {
      * @param amount    the amount of times to add the tile.
      */
     private void removeMultiple(Tile tile, int startX, int startY, Direction direction, int amount) {
-        int iterations = 0;
-
         int width = tile.getWidth();
         int height = tile.getHeight();
 
-        while (iterations <= amount) {
-            iterations++;
+        for (int i = 0; i < amount; i++) {
             remove(startX, startY);
 
             startX = direction == Direction.RIGHT ? startX + width : direction == Direction.LEFT ? startX - width : startX;

--- a/src/main/java/com/lunar/world/WorldMap.java
+++ b/src/main/java/com/lunar/world/WorldMap.java
@@ -14,7 +14,7 @@ import java.util.Map;
  */
 public abstract class WorldMap {
 
-    private final Map<Location, Tile> TILE_MAP = new HashMap<>();
+    protected final Map<Location, Tile> TILE_MAP = new HashMap<>();
 
     /**
      * Add a tile.
@@ -70,7 +70,7 @@ public abstract class WorldMap {
         int width = tile.getWidth();
         int height = tile.getHeight();
 
-        while (iterations <= amount) {
+        while (iterations < amount) {
             iterations++;
             tile.setY(startY);
             tile.setX(startX);

--- a/src/test/java/com/lunar/tile/TestTile.java
+++ b/src/test/java/com/lunar/tile/TestTile.java
@@ -1,0 +1,16 @@
+package com.lunar.tile;
+
+import com.lunar.tile.Tile;
+
+import java.awt.image.BufferedImage;
+
+public class TestTile extends Tile {
+    public static int TILE_COUNTER = 0;
+    public TestTile() {
+        this(1, 1);
+    }
+
+    public TestTile(int width, int height) {
+        super(new BufferedImage(width, height, BufferedImage.TYPE_BYTE_GRAY), TILE_COUNTER++);
+    }
+}

--- a/src/test/java/com/lunar/world/WorldTest.java
+++ b/src/test/java/com/lunar/world/WorldTest.java
@@ -1,20 +1,16 @@
 package com.lunar.world;
 
-import com.lunar.entity.Entity;
-import com.lunar.entity.TestEntity;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- * Created by Rick on 10/21/17.
- */
+import com.lunar.entity.Entity;
+import com.lunar.entity.TestEntity;
+import com.lunar.tile.TestTile;
+import com.lunar.tile.Tile;
+import com.lunar.world.dir.Direction;
+import org.junit.jupiter.api.*;
+
 class WorldTest {
     private TestWorld world;
 
@@ -28,9 +24,7 @@ class WorldTest {
         world = null;
     }
 
-    /**
-     * World Entity Tests
-     **/
+    /** World Entity Tests **/
     @Nested
     @Tag("world_entity")
     @DisplayName("entity handling")
@@ -39,7 +33,6 @@ class WorldTest {
         @DisplayName("manipulate world entity list")
         class ManipulateWorldEntityList {
             TestEntity ent;
-
             @BeforeEach
             void addEntity() {
                 ent = new TestEntity();
@@ -122,7 +115,62 @@ class WorldTest {
         @Test
         @DisplayName("get list of world entities")
         void TestGetWorldEntities() {
-            assertEquals(world.worldEntities, world.getWorldEntities(), "Expected to get the correct list of entities");
+            assertEquals(world.WORLD_ENTITIES, world.getWorldEntities(), "Expected to get the correct list of entities");
+        }
+    }
+
+    @Nested
+    @Tag("world_tile")
+    @DisplayName("tile handling")
+    class TileHandling {
+        @Test
+        @DisplayName("add tile with coordinates")
+        void TestAddTileToCoordinates() {
+            TestTile tile = new TestTile();
+            world.set(1, 2, tile);
+            assertEquals(1, world.TILE_MAP.size(), "Expected one tile to be in the map after adding.");
+            assertEquals(0, tile.getX(), "Expected the coordinates of the tile to not change");
+            assertEquals(0, tile.getY(), "Expected the coordinates of the tile to not change");
+        }
+
+        @Test
+        @DisplayName("add tile")
+        void TestAddTile() {
+            world.set(new TestTile());
+            assertEquals(1, world.TILE_MAP.size());
+        }
+
+        @Test
+        @DisplayName("add batch tiles")
+        void TestAddBatchTiles() {
+            int numTiles = 10;
+            TestTile tile = new TestTile(10, 10);
+            world.setMultiple(tile, 0, 0, Direction.RIGHT, numTiles, false);
+            world.setMultiple(tile, 0, 10, Direction.LEFT, numTiles, false);
+            world.setMultiple(tile, 0,120, Direction.UP, numTiles, false);
+            world.setMultiple(tile, 10,20, Direction.DOWN, numTiles, false);
+            assertEquals(numTiles * 4, world.TILE_MAP.size(), "Expected there to be the correct number of tiles after adding");
+            // Test Direction.RIGHT
+            for (int i = 0; i < numTiles; i++) {
+                Tile got = world.get(i*10, 0);
+                assertNotNull(got, String.format("Expected to find tile at (%d, %d)", i*10, 0));
+            }
+            // Test Direction.LEFT
+            for (int i = 0; i < numTiles; i++) {
+                assertNotNull(world.get(-i * 10, 10), String.format("Expected to find tile at (%d, %d)", i*10, 10));
+            }
+            // Test Direction.UP
+            for (int i = 0; i < numTiles; i++) {
+                int x = 0;
+                int y = 120 - i * 10;
+                assertNotNull(world.get(x, y), String.format("Expected to find tile at (%d, %d)", x, y));
+            }
+            // Test Direction.DOWN
+            for (int i = 0; i < numTiles; i++) {
+                int x = 10;
+                int y = 20 + i*10;
+                assertNotNull(world.get(x, y), String.format("Expected to find tile at (%d, %d)", x, y));
+            }
         }
     }
 }


### PR DESCRIPTION
**DO NOT MERGE**

WIP means don't merge yet.

Some changes were made to the world class that broke the world tests. This should have been updated when making those changes, that's the entire point of testing. Furthermore, the tests exposed two bugs in the changes @Vrekt made.
1. `WorldMap#setMultiple` was adding an extra tile per call because of the use of `<=`
2. `WorldMap#get` just flat out doesn't work. When using `get` on a HashMap, it only works if either a) you are using the same reference, in this case, the same `Location` object that was originally made or b) `hashCode` and `equals` are implemented for the object to compute "equality".

I still need to address point 2 for this code to work, until then **do not merge**. Also, start testing changes if you're going to commit/merge into master without review so it doesn't break things downstream for us.